### PR TITLE
Fix condition under which C++11 ABI symbol is used

### DIFF
--- a/Tokenize/filters/FilterFactory.cc
+++ b/Tokenize/filters/FilterFactory.cc
@@ -42,11 +42,10 @@
 #endif
 #endif
 
-#if defined(__llvm__)
+#if defined _GLIBCXX_USE_CXX11_ABI && _GLIBCXX_USE_CXX11_ABI
 #define GETFILTERTYPESFUNC	"_Z16get_filter_typesRNSt3__13setINS_12basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEEENS_4lessIS6_EENS4_IS6_EEEE"
 #define GETFILTERFUNC		"_Z10get_filterRKNSt3__112basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEEE"
 #else
-// Assume __GNUC__
 #define GETFILTERTYPESFUNC	"_Z16get_filter_typesRSt3setISsSt4lessISsESaISsEE"
 #define GETFILTERFUNC		"_Z10get_filterRKSs"
 #endif


### PR DESCRIPTION
The current code fails with GCC6 on Debian unstable.  I believe the updated conditional should be correct for all GCC and clang versions.

There's more info at: http://developers.redhat.com/blog/2015/02/10/gcc-5-in-fedora/