### PR TITLE
Fix GCC C++11 -Wliteral-suffix warning

### DIFF
--- a/Tokenize/filters/GMimeMboxFilter.cc
+++ b/Tokenize/filters/GMimeMboxFilter.cc
@@ -301,7 +301,7 @@ bool GMimeMboxFilter::skip_to_document(const string &ipath)
 	}
 
 	// ipath's format is "o=offset&l=part_levels"
-	if (sscanf(ipath.c_str(), "o="GMIME_OFFSET_MODIFIER"&l=[", &m_messageStart) != 1)
+	if (sscanf(ipath.c_str(), "o=" GMIME_OFFSET_MODIFIER "&l=[", &m_messageStart) != 1)
 	{
 		return false;
 	}


### PR DESCRIPTION
../Tokenize/filters/GMimeMboxFilter.cc:304:28: warning: invalid suffix on literal; C++11 requires a space between literal and string macro [-Wliteral-suffix]
  if (sscanf(ipath.c_str(), "o="GMIME_OFFSET_MODIFIER"&l=[", &m_messageStart) != 1)
                            ^