### PR TITLE
Fix widespread typos for "occurred"

### DIFF
--- a/Core/ServerThreads.cpp
+++ b/Core/ServerThreads.cpp
@@ -1099,7 +1099,7 @@ void DBusServletThread::doWork(void)
 	if (error.message != NULL)
 	{
 #ifdef DEBUG
-		clog << "DBusServletThread::doWork: error occured: " << error.message << endl;
+		clog << "DBusServletThread::doWork: error occurred: " << error.message << endl;
 #endif
 		// Use the error message as reply
 		m_pServletInfo->newErrorReply(error.name, error.message);

--- a/Core/WorkerThreads.cpp
+++ b/Core/WorkerThreads.cpp
@@ -1668,7 +1668,7 @@ bool DirectoryScannerThread::scanEntry(const string &entryName,
 		recordCrawled(location, fileStat.st_mtime);
 	}
 
-	// If a major error occured, this won't be true
+	// If a major error occurred, this won't be true
 	if (reportFile == true)
 	{
 		if (docInfo.getType().empty() == true)

--- a/IndexSearch/ResultsExporter.h
+++ b/IndexSearch/ResultsExporter.h
@@ -71,7 +71,7 @@ class CSVExporter : public ResultsExporter
 			const QueryProperties &queryProps);
 		virtual ~CSVExporter();
 
-		/// Exports the results; false if an error occured.
+		/// Exports the results; false if an error occurred.
 		virtual bool exportResults(const std::string &engineName,
 			unsigned int maxResultsCount,
 			const std::vector<DocumentInfo> &resultsList);
@@ -104,7 +104,7 @@ class OpenSearchExporter : public ResultsExporter
 			const QueryProperties &queryProps);
 		virtual ~OpenSearchExporter();
 
-		/// Exports the results; false if an error occured.
+		/// Exports the results; false if an error occurred.
 		virtual bool exportResults(const std::string &engineName,
 			unsigned int maxResultsCount,
 			const std::vector<DocumentInfo> &resultsList);

--- a/IndexSearch/Xapian/XapianIndex.cpp
+++ b/IndexSearch/Xapian/XapianIndex.cpp
@@ -359,7 +359,7 @@ bool XapianIndex::listDocumentsWithTerm(const string &term, set<unsigned int> &d
 	}
 	catch (...)
 	{
-		clog << "Couldn't get document list, unknown exception occured" << endl;
+		clog << "Couldn't get document list, unknown exception occurred" << endl;
 	}
 	pDatabase->unlock();
 
@@ -1048,7 +1048,7 @@ bool XapianIndex::deleteDocuments(const string &term)
 	}
 	catch (...)
 	{
-		clog << "Couldn't unindex documents, unknown exception occured" << endl;
+		clog << "Couldn't unindex documents, unknown exception occurred" << endl;
 	}
 	pDatabase->unlock();
 
@@ -1094,7 +1094,7 @@ string XapianIndex::getMetadata(const string &name) const
 	}
 	catch (...)
 	{
-		clog << "Couldn't get metadata, unknown exception occured" << endl;
+		clog << "Couldn't get metadata, unknown exception occurred" << endl;
 	}
 	pDatabase->unlock();
 
@@ -1136,7 +1136,7 @@ bool XapianIndex::setMetadata(const string &name, const string &value) const
 	}
 	catch (...)
 	{
-		clog << "Couldn't set metadata, unknown exception occured" << endl;
+		clog << "Couldn't set metadata, unknown exception occurred" << endl;
 	}
 	pDatabase->unlock();
 
@@ -1193,7 +1193,7 @@ bool XapianIndex::getDocumentInfo(unsigned int docId, DocumentInfo &docInfo) con
 	}
 	catch (...)
 	{
-		clog << "Couldn't get document properties, unknown exception occured" << endl;
+		clog << "Couldn't get document properties, unknown exception occurred" << endl;
 	}
 	pDatabase->unlock();
 
@@ -1231,7 +1231,7 @@ unsigned int XapianIndex::getDocumentTermsCount(unsigned int docId) const
 	}
 	catch (...)
 	{
-		clog << "Couldn't get document terms count, unknown exception occured" << endl;
+		clog << "Couldn't get document terms count, unknown exception occurred" << endl;
 	}
 	pDatabase->unlock();
 
@@ -1316,7 +1316,7 @@ bool XapianIndex::getDocumentTerms(unsigned int docId, map<unsigned int, string>
 	}
 	catch (...)
 	{
-		clog << "Couldn't get document terms, unknown exception occured" << endl;
+		clog << "Couldn't get document terms, unknown exception occurred" << endl;
 	}
 	pDatabase->unlock();
 
@@ -1428,7 +1428,7 @@ bool XapianIndex::deleteLabel(const string &name)
 	}
 	catch (...)
 	{
-		clog << "Couldn't delete label, unknown exception occured" << endl;
+		clog << "Couldn't delete label, unknown exception occurred" << endl;
 	}
 	pDatabase->unlock();
 
@@ -1476,7 +1476,7 @@ bool XapianIndex::hasLabel(unsigned int docId, const string &name) const
 	}
 	catch (...)
 	{
-		clog << "Couldn't check document labels, unknown exception occured" << endl;
+		clog << "Couldn't check document labels, unknown exception occurred" << endl;
 	}
 	pDatabase->unlock();
 
@@ -1528,7 +1528,7 @@ bool XapianIndex::getDocumentLabels(unsigned int docId, set<string> &labels) con
 	}
 	catch (...)
 	{
-		clog << "Couldn't get document's labels, unknown exception occured" << endl;
+		clog << "Couldn't get document's labels, unknown exception occurred" << endl;
 	}
 	pDatabase->unlock();
 
@@ -1605,7 +1605,7 @@ bool XapianIndex::setDocumentsLabels(const set<unsigned int> &docIds,
 		}
 		catch (...)
 		{
-			clog << "Couldn't update document's labels, unknown exception occured" << endl;
+			clog << "Couldn't update document's labels, unknown exception occurred" << endl;
 		}
 
 		pDatabase->unlock();
@@ -1653,7 +1653,7 @@ unsigned int XapianIndex::hasDocument(const string &url) const
 	}
 	catch (...)
 	{
-		clog << "Couldn't look for document, unknown exception occured" << endl;
+		clog << "Couldn't look for document, unknown exception occurred" << endl;
 	}
 	pDatabase->unlock();
 
@@ -1715,7 +1715,7 @@ unsigned int XapianIndex::getCloseTerms(const string &term, set<string> &suggest
 	}
 	catch (...)
 	{
-		clog << "Couldn't get terms, unknown exception occured" << endl;
+		clog << "Couldn't get terms, unknown exception occurred" << endl;
 	}
 	pDatabase->unlock();
 
@@ -1748,7 +1748,7 @@ unsigned int XapianIndex::getLastDocumentID(void) const
 	}
 	catch (...)
 	{
-		clog << "Couldn't get last document ID, unknown exception occured" << endl;
+		clog << "Couldn't get last document ID, unknown exception occurred" << endl;
 	}
 	pDatabase->unlock();
 
@@ -1793,7 +1793,7 @@ unsigned int XapianIndex::getDocumentsCount(const string &labelName) const
 	}
 	catch (...)
 	{
-		clog << "Couldn't count documents, unknown exception occured" << endl;
+		clog << "Couldn't count documents, unknown exception occurred" << endl;
 	}
 	pDatabase->unlock();
 
@@ -1897,7 +1897,7 @@ bool XapianIndex::indexDocument(const Document &document, const std::set<std::st
 	}
 	catch (...)
 	{
-		clog << "Couldn't index document, unknown exception occured" << endl;
+		clog << "Couldn't index document, unknown exception occurred" << endl;
 	}
 	pDatabase->unlock();
 
@@ -1974,7 +1974,7 @@ bool XapianIndex::updateDocument(unsigned int docId, const Document &document)
 	}
 	catch (...)
 	{
-		clog << "Couldn't update document, unknown exception occured" << endl;
+		clog << "Couldn't update document, unknown exception occurred" << endl;
 	}
 	if (pIndex != NULL)
 	{
@@ -2025,7 +2025,7 @@ bool XapianIndex::updateDocumentInfo(unsigned int docId, const DocumentInfo &doc
 	}
 	catch (...)
 	{
-		clog << "Couldn't update document properties, unknown exception occured" << endl;
+		clog << "Couldn't update document properties, unknown exception occurred" << endl;
 	}
 	pDatabase->unlock();
 
@@ -2065,7 +2065,7 @@ bool XapianIndex::unindexDocument(unsigned int docId)
 	}
 	catch (...)
 	{
-		clog << "Couldn't unindex document, unknown exception occured" << endl;
+		clog << "Couldn't unindex document, unknown exception occurred" << endl;
 	}
 	pDatabase->unlock();
 
@@ -2135,7 +2135,7 @@ bool XapianIndex::flush(void)
 	}
 	catch (...)
 	{
-		clog << "Couldn't flush database, unknown exception occured" << endl;
+		clog << "Couldn't flush database, unknown exception occurred" << endl;
 	}
 	pDatabase->unlock();
 

--- a/Tokenize/filters/ArchiveFilter.h
+++ b/Tokenize/filters/ArchiveFilter.h
@@ -56,26 +56,26 @@ namespace Dijon
 	 * Filter object is destroyed, as some filters may not need to
 	 * do a deep copy of the data.
 	 * Call next_document() to position the filter onto the first document.
-	 * Returns false if this input is not supported or an error occured.
+	 * Returns false if this input is not supported or an error occurred.
 	 */
 	virtual bool set_document_data(const char *data_ptr, off_t data_length);
 
 	/** (Re)initializes the filter with the given data.
 	 * Call next_document() to position the filter onto the first document.
-	 * Returns false if this input is not supported or an error occured.
+	 * Returns false if this input is not supported or an error occurred.
 	 */
 	virtual bool set_document_string(const std::string &data_str);
 
 	/** (Re)initializes the filter with the given file.
 	 * Call next_document() to position the filter onto the first document.
-	 * Returns false if this input is not supported or an error occured.
+	 * Returns false if this input is not supported or an error occurred.
 	 */
 	virtual bool set_document_file(const std::string &file_path,
 		bool unlink_when_done = false);
 
 	/** (Re)initializes the filter with the given URI.
 	 * Call next_document() to position the filter onto the first document.
-	 * Returns false if this input is not supported or an error occured.
+	 * Returns false if this input is not supported or an error occurred.
 	 */
 	virtual bool set_document_uri(const std::string &uri);
 
@@ -84,7 +84,7 @@ namespace Dijon
 
 	/** Returns true if there are nested documents left to extract.
 	 * Returns false if the end of the parent document was reached
-	 * or an error occured.
+	 * or an error occurred.
 	 */
 	virtual bool has_documents(void) const;
 
@@ -101,7 +101,7 @@ namespace Dijon
 
 	// Accessing documents' contents.
 
-	/// Returns the message for the most recent error that has occured.
+	/// Returns the message for the most recent error that has occurred.
 	virtual std::string get_error(void) const;
 
     protected:

--- a/Tokenize/filters/ChmFilter.h
+++ b/Tokenize/filters/ChmFilter.h
@@ -54,26 +54,26 @@ namespace Dijon
 	 * Filter object is destroyed, as some filters may not need to
 	 * do a deep copy of the data.
 	 * Call next_document() to position the filter onto the first document.
-	 * Returns false if this input is not supported or an error occured.
+	 * Returns false if this input is not supported or an error occurred.
 	 */
 	virtual bool set_document_data(const char *data_ptr, off_t data_length);
 
 	/** (Re)initializes the filter with the given data.
 	 * Call next_document() to position the filter onto the first document.
-	 * Returns false if this input is not supported or an error occured.
+	 * Returns false if this input is not supported or an error occurred.
 	 */
 	virtual bool set_document_string(const std::string &data_str);
 
 	/** (Re)initializes the filter with the given file.
 	 * Call next_document() to position the filter onto the first document.
-	 * Returns false if this input is not supported or an error occured.
+	 * Returns false if this input is not supported or an error occurred.
 	 */
 	virtual bool set_document_file(const std::string &file_path,
 		bool unlink_when_done = false);
 
 	/** (Re)initializes the filter with the given URI.
 	 * Call next_document() to position the filter onto the first document.
-	 * Returns false if this input is not supported or an error occured.
+	 * Returns false if this input is not supported or an error occurred.
 	 */
 	virtual bool set_document_uri(const std::string &uri);
 
@@ -82,7 +82,7 @@ namespace Dijon
 
 	/** Returns true if there are nested documents left to extract.
 	 * Returns false if the end of the parent document was reached
-	 * or an error occured.
+	 * or an error occurred.
 	 */
 	virtual bool has_documents(void) const;
 
@@ -99,7 +99,7 @@ namespace Dijon
 
 	// Accessing documents' contents.
 
-	/// Returns the message for the most recent error that has occured.
+	/// Returns the message for the most recent error that has occurred.
 	virtual std::string get_error(void) const;
 
 	// Enumeration.

--- a/Tokenize/filters/ExifImageFilter.h
+++ b/Tokenize/filters/ExifImageFilter.h
@@ -52,26 +52,26 @@ namespace Dijon
 	 * Filter object is destroyed, as some filters may not need to
 	 * do a deep copy of the data.
 	 * Call next_document() to position the filter onto the first document.
-	 * Returns false if this input is not supported or an error occured.
+	 * Returns false if this input is not supported or an error occurred.
 	 */
 	virtual bool set_document_data(const char *data_ptr, off_t data_length);
 
 	/** (Re)initializes the filter with the given data.
 	 * Call next_document() to position the filter onto the first document.
-	 * Returns false if this input is not supported or an error occured.
+	 * Returns false if this input is not supported or an error occurred.
 	 */
 	virtual bool set_document_string(const std::string &data_str);
 
 	/** (Re)initializes the filter with the given file.
 	 * Call next_document() to position the filter onto the first document.
-	 * Returns false if this input is not supported or an error occured.
+	 * Returns false if this input is not supported or an error occurred.
 	 */
 	virtual bool set_document_file(const std::string &file_path,
 		bool unlink_when_done = false);
 
 	/** (Re)initializes the filter with the given URI.
 	 * Call next_document() to position the filter onto the first document.
-	 * Returns false if this input is not supported or an error occured.
+	 * Returns false if this input is not supported or an error occurred.
 	 */
 	virtual bool set_document_uri(const std::string &uri);
 
@@ -80,7 +80,7 @@ namespace Dijon
 
 	/** Returns true if there are nested documents left to extract.
 	 * Returns false if the end of the parent document was reached
-	 * or an error occured.
+	 * or an error occurred.
 	 */
 	virtual bool has_documents(void) const;
 
@@ -97,7 +97,7 @@ namespace Dijon
 
 	// Accessing documents' contents.
 
-	/// Returns the message for the most recent error that has occured.
+	/// Returns the message for the most recent error that has occurred.
 	virtual std::string get_error(void) const;
 
     protected:

--- a/Tokenize/filters/Exiv2ImageFilter.h
+++ b/Tokenize/filters/Exiv2ImageFilter.h
@@ -52,26 +52,26 @@ namespace Dijon
 	 * Filter object is destroyed, as some filters may not need to
 	 * do a deep copy of the data.
 	 * Call next_document() to position the filter onto the first document.
-	 * Returns false if this input is not supported or an error occured.
+	 * Returns false if this input is not supported or an error occurred.
 	 */
 	virtual bool set_document_data(const char *data_ptr, off_t data_length);
 
 	/** (Re)initializes the filter with the given data.
 	 * Call next_document() to position the filter onto the first document.
-	 * Returns false if this input is not supported or an error occured.
+	 * Returns false if this input is not supported or an error occurred.
 	 */
 	virtual bool set_document_string(const std::string &data_str);
 
 	/** (Re)initializes the filter with the given file.
 	 * Call next_document() to position the filter onto the first document.
-	 * Returns false if this input is not supported or an error occured.
+	 * Returns false if this input is not supported or an error occurred.
 	 */
 	virtual bool set_document_file(const std::string &file_path,
 		bool unlink_when_done = false);
 
 	/** (Re)initializes the filter with the given URI.
 	 * Call next_document() to position the filter onto the first document.
-	 * Returns false if this input is not supported or an error occured.
+	 * Returns false if this input is not supported or an error occurred.
 	 */
 	virtual bool set_document_uri(const std::string &uri);
 
@@ -80,7 +80,7 @@ namespace Dijon
 
 	/** Returns true if there are nested documents left to extract.
 	 * Returns false if the end of the parent document was reached
-	 * or an error occured.
+	 * or an error occurred.
 	 */
 	virtual bool has_documents(void) const;
 
@@ -97,7 +97,7 @@ namespace Dijon
 
 	// Accessing documents' contents.
 
-	/// Returns the message for the most recent error that has occured.
+	/// Returns the message for the most recent error that has occurred.
 	virtual std::string get_error(void) const;
 
     protected:

--- a/Tokenize/filters/ExternalFilter.h
+++ b/Tokenize/filters/ExternalFilter.h
@@ -58,19 +58,19 @@ namespace Dijon
 	 * Filter object is destroyed, as some filters may not need to
 	 * do a deep copy of the data.
 	 * Call next_document() to position the filter onto the first document.
-	 * Returns false if this input is not supported or an error occured.
+	 * Returns false if this input is not supported or an error occurred.
 	 */
 	virtual bool set_document_data(const char *data_ptr, off_t data_length);
 
 	/** (Re)initializes the filter with the given data.
 	 * Call next_document() to position the filter onto the first document.
-	 * Returns false if this input is not supported or an error occured.
+	 * Returns false if this input is not supported or an error occurred.
 	 */
 	virtual bool set_document_string(const std::string &data_str);
 
 	/** (Re)initializes the filter with the given URI.
 	 * Call next_document() to position the filter onto the first document.
-	 * Returns false if this input is not supported or an error occured.
+	 * Returns false if this input is not supported or an error occurred.
 	 */
 	virtual bool set_document_uri(const std::string &uri);
 
@@ -79,7 +79,7 @@ namespace Dijon
 
 	/** Returns true if there are nested documents left to extract.
 	 * Returns false if the end of the parent document was reached
-	 * or an error occured.
+	 * or an error occurred.
 	 */
 	virtual bool has_documents(void) const;
 
@@ -96,7 +96,7 @@ namespace Dijon
 
 	// Accessing documents' contents.
 
-	/// Returns the message for the most recent error that has occured.
+	/// Returns the message for the most recent error that has occurred.
 	virtual std::string get_error(void) const;
 
     protected:

--- a/Tokenize/filters/FileOutputFilter.cc
+++ b/Tokenize/filters/FileOutputFilter.cc
@@ -69,7 +69,7 @@ bool FileOutputFilter::read_file(int fd, ssize_t maxSize, ssize_t &totalSize)
 		}
 		else if (bytesRead == -1)
 		{
-			// An error occured
+			// An error occurred
 			if (errno != EINTR)
 			{
 				gotOutput = false;

--- a/Tokenize/filters/Filter.h
+++ b/Tokenize/filters/Filter.h
@@ -133,26 +133,26 @@ namespace Dijon
 	 * Filter object is destroyed, as some filters may not need to
 	 * do a deep copy of the data.
 	 * Call next_document() to position the filter onto the first document.
-	 * Returns false if this input is not supported or an error occured.
+	 * Returns false if this input is not supported or an error occurred.
 	 */
 	virtual bool set_document_data(const char *data_ptr, off_t data_length) = 0;
 
 	/** (Re)initializes the filter with the given data.
 	 * Call next_document() to position the filter onto the first document.
-	 * Returns false if this input is not supported or an error occured.
+	 * Returns false if this input is not supported or an error occurred.
 	 */
 	virtual bool set_document_string(const std::string &data_str) = 0;
 
 	/** (Re)initializes the filter with the given file.
 	 * Call next_document() to position the filter onto the first document.
-	 * Returns false if this input is not supported or an error occured.
+	 * Returns false if this input is not supported or an error occurred.
 	 */
 	virtual bool set_document_file(const std::string &file_path,
 		bool unlink_when_done = false);
 
 	/** (Re)initializes the filter with the given URI.
 	 * Call next_document() to position the filter onto the first document.
-	 * Returns false if this input is not supported or an error occured.
+	 * Returns false if this input is not supported or an error occurred.
 	 */
 	virtual bool set_document_uri(const std::string &uri) = 0;
 
@@ -161,7 +161,7 @@ namespace Dijon
 
 	/** Returns true if there are nested documents left to extract.
 	 * Returns false if the end of the parent document was reached
-	 * or an error occured.
+	 * or an error occurred.
 	 */
 	virtual bool has_documents(void) const = 0;
 
@@ -178,7 +178,7 @@ namespace Dijon
 
 	// Accessing documents' contents.
 
-	/// Returns the message for the most recent error that has occured.
+	/// Returns the message for the most recent error that has occurred.
 	virtual std::string get_error(void) const = 0;
 
 	/** Returns a dictionary of metadata extracted from the current document.

--- a/Tokenize/filters/GMimeMboxFilter.cc
+++ b/Tokenize/filters/GMimeMboxFilter.cc
@@ -569,7 +569,7 @@ bool GMimeMboxFilter::readStream(GMimeStream *pStream, dstring &fileBuffer)
 		}
 		else if (bytesRead == -1)
 		{
-			// An error occured
+			// An error occurred
 			if (errno != EINTR)
 			{
 				gotOutput = false;

--- a/Tokenize/filters/GMimeMboxFilter.h
+++ b/Tokenize/filters/GMimeMboxFilter.h
@@ -67,26 +67,26 @@ namespace Dijon
 	 * Filter object is destroyed, as some filters may not need to
 	 * do a deep copy of the data.
 	 * Call next_document() to position the filter onto the first document.
-	 * Returns false if this input is not supported or an error occured.
+	 * Returns false if this input is not supported or an error occurred.
 	 */
 	virtual bool set_document_data(const char *data_ptr, off_t data_length);
 
 	/** (Re)initializes the filter with the given data.
 	 * Call next_document() to position the filter onto the first document.
-	 * Returns false if this input is not supported or an error occured.
+	 * Returns false if this input is not supported or an error occurred.
 	 */
 	virtual bool set_document_string(const std::string &data_str);
 
 	/** (Re)initializes the filter with the given file.
 	 * Call next_document() to position the filter onto the first document.
-	 * Returns false if this input is not supported or an error occured.
+	 * Returns false if this input is not supported or an error occurred.
 	 */
 	virtual bool set_document_file(const std::string &file_path,
 		bool unlink_when_done = false);
 
 	/** (Re)initializes the filter with the given URI.
 	 * Call next_document() to position the filter onto the first document.
-	 * Returns false if this input is not supported or an error occured.
+	 * Returns false if this input is not supported or an error occurred.
 	 */
 	virtual bool set_document_uri(const std::string &uri);
 
@@ -95,7 +95,7 @@ namespace Dijon
 
 	/** Returns true if there are nested documents left to extract.
 	 * Returns false if the end of the parent document was reached
-	 * or an error occured.
+	 * or an error occurred.
 	 */
 	virtual bool has_documents(void) const;
 
@@ -112,7 +112,7 @@ namespace Dijon
 
 	// Accessing documents' contents.
 
-	/// Returns the message for the most recent error that has occured.
+	/// Returns the message for the most recent error that has occurred.
 	virtual std::string get_error(void) const;
 
     protected:

--- a/Tokenize/filters/HtmlFilter.h
+++ b/Tokenize/filters/HtmlFilter.h
@@ -72,26 +72,26 @@ namespace Dijon
 	 * Filter object is destroyed, as some filters may not need to
 	 * do a deep copy of the data.
 	 * Call next_document() to position the filter onto the first document.
-	 * Returns false if this input is not supported or an error occured.
+	 * Returns false if this input is not supported or an error occurred.
 	 */
 	virtual bool set_document_data(const char *data_ptr, off_t data_length);
 
 	/** (Re)initializes the filter with the given data.
 	 * Call next_document() to position the filter onto the first document.
-	 * Returns false if this input is not supported or an error occured.
+	 * Returns false if this input is not supported or an error occurred.
 	 */
 	virtual bool set_document_string(const std::string &data_str);
 
 	/** (Re)initializes the filter with the given file.
 	 * Call next_document() to position the filter onto the first document.
-	 * Returns false if this input is not supported or an error occured.
+	 * Returns false if this input is not supported or an error occurred.
 	 */
 	virtual bool set_document_file(const std::string &file_path,
 		bool unlink_when_done = false);
 
 	/** (Re)initializes the filter with the given URI.
 	 * Call next_document() to position the filter onto the first document.
-	 * Returns false if this input is not supported or an error occured.
+	 * Returns false if this input is not supported or an error occurred.
 	 */
 	virtual bool set_document_uri(const std::string &uri);
 
@@ -100,7 +100,7 @@ namespace Dijon
 
 	/** Returns true if there are nested documents left to extract.
 	 * Returns false if the end of the parent document was reached
-	 * or an error occured.
+	 * or an error occurred.
 	 */
 	virtual bool has_documents(void) const;
 
@@ -117,7 +117,7 @@ namespace Dijon
 
 	// Accessing documents' contents.
 
-	/// Returns the message for the most recent error that has occured.
+	/// Returns the message for the most recent error that has occurred.
 	virtual std::string get_error(void) const;
 
 	/// Returns the links set.

--- a/Tokenize/filters/JsonFilter.h
+++ b/Tokenize/filters/JsonFilter.h
@@ -53,26 +53,26 @@ namespace Dijon
 	 * Filter object is destroyed, as some filters may not need to
 	 * do a deep copy of the data.
 	 * Call next_document() to position the filter onto the first document.
-	 * Returns false if this input is not supported or an error occured.
+	 * Returns false if this input is not supported or an error occurred.
 	 */
 	virtual bool set_document_data(const char *data_ptr, off_t data_length);
 
 	/** (Re)initializes the filter with the given data.
 	 * Call next_document() to position the filter onto the first document.
-	 * Returns false if this input is not supported or an error occured.
+	 * Returns false if this input is not supported or an error occurred.
 	 */
 	virtual bool set_document_string(const std::string &data_str);
 
 	/** (Re)initializes the filter with the given file.
 	 * Call next_document() to position the filter onto the first document.
-	 * Returns false if this input is not supported or an error occured.
+	 * Returns false if this input is not supported or an error occurred.
 	 */
 	virtual bool set_document_file(const std::string &file_path,
 		bool unlink_when_done = false);
 
 	/** (Re)initializes the filter with the given URI.
 	 * Call next_document() to position the filter onto the first document.
-	 * Returns false if this input is not supported or an error occured.
+	 * Returns false if this input is not supported or an error occurred.
 	 */
 	virtual bool set_document_uri(const std::string &uri);
 
@@ -81,7 +81,7 @@ namespace Dijon
 
 	/** Returns true if there are nested documents left to extract.
 	 * Returns false if the end of the parent document was reached
-	 * or an error occured.
+	 * or an error occurred.
 	 */
 	virtual bool has_documents(void) const;
 
@@ -98,7 +98,7 @@ namespace Dijon
 
 	// Accessing documents' contents.
 
-	/// Returns the message for the most recent error that has occured.
+	/// Returns the message for the most recent error that has occurred.
 	virtual std::string get_error(void) const;
 
     protected:

--- a/Tokenize/filters/TagLibMusicFilter.h
+++ b/Tokenize/filters/TagLibMusicFilter.h
@@ -52,26 +52,26 @@ namespace Dijon
 	 * Filter object is destroyed, as some filters may not need to
 	 * do a deep copy of the data.
 	 * Call next_document() to position the filter onto the first document.
-	 * Returns false if this input is not supported or an error occured.
+	 * Returns false if this input is not supported or an error occurred.
 	 */
 	virtual bool set_document_data(const char *data_ptr, off_t data_length);
 
 	/** (Re)initializes the filter with the given data.
 	 * Call next_document() to position the filter onto the first document.
-	 * Returns false if this input is not supported or an error occured.
+	 * Returns false if this input is not supported or an error occurred.
 	 */
 	virtual bool set_document_string(const std::string &data_str);
 
 	/** (Re)initializes the filter with the given file.
 	 * Call next_document() to position the filter onto the first document.
-	 * Returns false if this input is not supported or an error occured.
+	 * Returns false if this input is not supported or an error occurred.
 	 */
 	virtual bool set_document_file(const std::string &file_path,
 		bool unlink_when_done = false);
 
 	/** (Re)initializes the filter with the given URI.
 	 * Call next_document() to position the filter onto the first document.
-	 * Returns false if this input is not supported or an error occured.
+	 * Returns false if this input is not supported or an error occurred.
 	 */
 	virtual bool set_document_uri(const std::string &uri);
 
@@ -80,7 +80,7 @@ namespace Dijon
 
 	/** Returns true if there are nested documents left to extract.
 	 * Returns false if the end of the parent document was reached
-	 * or an error occured.
+	 * or an error occurred.
 	 */
 	virtual bool has_documents(void) const;
 
@@ -97,7 +97,7 @@ namespace Dijon
 
 	// Accessing documents' contents.
 
-	/// Returns the message for the most recent error that has occured.
+	/// Returns the message for the most recent error that has occurred.
 	virtual std::string get_error(void) const;
 
     protected:

--- a/Tokenize/filters/TarFilter.h
+++ b/Tokenize/filters/TarFilter.h
@@ -53,26 +53,26 @@ namespace Dijon
 	 * Filter object is destroyed, as some filters may not need to
 	 * do a deep copy of the data.
 	 * Call next_document() to position the filter onto the first document.
-	 * Returns false if this input is not supported or an error occured.
+	 * Returns false if this input is not supported or an error occurred.
 	 */
 	virtual bool set_document_data(const char *data_ptr, off_t data_length);
 
 	/** (Re)initializes the filter with the given data.
 	 * Call next_document() to position the filter onto the first document.
-	 * Returns false if this input is not supported or an error occured.
+	 * Returns false if this input is not supported or an error occurred.
 	 */
 	virtual bool set_document_string(const std::string &data_str);
 
 	/** (Re)initializes the filter with the given file.
 	 * Call next_document() to position the filter onto the first document.
-	 * Returns false if this input is not supported or an error occured.
+	 * Returns false if this input is not supported or an error occurred.
 	 */
 	virtual bool set_document_file(const std::string &file_path,
 		bool unlink_when_done = false);
 
 	/** (Re)initializes the filter with the given URI.
 	 * Call next_document() to position the filter onto the first document.
-	 * Returns false if this input is not supported or an error occured.
+	 * Returns false if this input is not supported or an error occurred.
 	 */
 	virtual bool set_document_uri(const std::string &uri);
 
@@ -81,7 +81,7 @@ namespace Dijon
 
 	/** Returns true if there are nested documents left to extract.
 	 * Returns false if the end of the parent document was reached
-	 * or an error occured.
+	 * or an error occurred.
 	 */
 	virtual bool has_documents(void) const;
 
@@ -98,7 +98,7 @@ namespace Dijon
 
 	// Accessing documents' contents.
 
-	/// Returns the message for the most recent error that has occured.
+	/// Returns the message for the most recent error that has occurred.
 	virtual std::string get_error(void) const;
 
     protected:

--- a/Tokenize/filters/TextFilter.h
+++ b/Tokenize/filters/TextFilter.h
@@ -52,26 +52,26 @@ namespace Dijon
 	 * Filter object is destroyed, as some filters may not need to
 	 * do a deep copy of the data.
 	 * Call next_document() to position the filter onto the first document.
-	 * Returns false if this input is not supported or an error occured.
+	 * Returns false if this input is not supported or an error occurred.
 	 */
 	virtual bool set_document_data(const char *data_ptr, off_t data_length);
 
 	/** (Re)initializes the filter with the given data.
 	 * Call next_document() to position the filter onto the first document.
-	 * Returns false if this input is not supported or an error occured.
+	 * Returns false if this input is not supported or an error occurred.
 	 */
 	virtual bool set_document_string(const std::string &data_str);
 
 	/** (Re)initializes the filter with the given file.
 	 * Call next_document() to position the filter onto the first document.
-	 * Returns false if this input is not supported or an error occured.
+	 * Returns false if this input is not supported or an error occurred.
 	 */
 	virtual bool set_document_file(const std::string &file_path,
 		bool unlink_when_done = false);
 
 	/** (Re)initializes the filter with the given URI.
 	 * Call next_document() to position the filter onto the first document.
-	 * Returns false if this input is not supported or an error occured.
+	 * Returns false if this input is not supported or an error occurred.
 	 */
 	virtual bool set_document_uri(const std::string &uri);
 
@@ -80,7 +80,7 @@ namespace Dijon
 
 	/** Returns true if there are nested documents left to extract.
 	 * Returns false if the end of the parent document was reached
-	 * or an error occured.
+	 * or an error occurred.
 	 */
 	virtual bool has_documents(void) const;
 
@@ -97,7 +97,7 @@ namespace Dijon
 
 	// Accessing documents' contents.
 
-	/// Returns the message for the most recent error that has occured.
+	/// Returns the message for the most recent error that has occurred.
 	virtual std::string get_error(void) const;
 
     protected:

--- a/Tokenize/filters/XmlFilter.h
+++ b/Tokenize/filters/XmlFilter.h
@@ -52,26 +52,26 @@ namespace Dijon
 	 * Filter object is destroyed, as some filters may not need to
 	 * do a deep copy of the data.
 	 * Call next_document() to position the filter onto the first document.
-	 * Returns false if this input is not supported or an error occured.
+	 * Returns false if this input is not supported or an error occurred.
 	 */
 	virtual bool set_document_data(const char *data_ptr, off_t data_length);
 
 	/** (Re)initializes the filter with the given data.
 	 * Call next_document() to position the filter onto the first document.
-	 * Returns false if this input is not supported or an error occured.
+	 * Returns false if this input is not supported or an error occurred.
 	 */
 	virtual bool set_document_string(const std::string &data_str);
 
 	/** (Re)initializes the filter with the given file.
 	 * Call next_document() to position the filter onto the first document.
-	 * Returns false if this input is not supported or an error occured.
+	 * Returns false if this input is not supported or an error occurred.
 	 */
 	virtual bool set_document_file(const std::string &file_path,
 		bool unlink_when_done = false);
 
 	/** (Re)initializes the filter with the given URI.
 	 * Call next_document() to position the filter onto the first document.
-	 * Returns false if this input is not supported or an error occured.
+	 * Returns false if this input is not supported or an error occurred.
 	 */
 	virtual bool set_document_uri(const std::string &uri);
 
@@ -80,7 +80,7 @@ namespace Dijon
 
 	/** Returns true if there are nested documents left to extract.
 	 * Returns false if the end of the parent document was reached
-	 * or an error occured.
+	 * or an error occurred.
 	 */
 	virtual bool has_documents(void) const;
 
@@ -97,7 +97,7 @@ namespace Dijon
 
 	// Accessing documents' contents.
 
-	/// Returns the message for the most recent error that has occured.
+	/// Returns the message for the most recent error that has occurred.
 	virtual std::string get_error(void) const;
 
     protected:

--- a/UI/GTK2/src/mainWindow.cc
+++ b/UI/GTK2/src/mainWindow.cc
@@ -1397,7 +1397,7 @@ void mainWindow::on_thread_end(WorkerThread *pThread)
 	{
 		// Yep, it did
 		set_status(to_utf8(threadStatus));
-		// Better reset that flag if an error occured while browsing an index
+		// Better reset that flag if an error occurred while browsing an index
 		if (type == "ListerThread")
 		{
 			m_state.m_browsingIndex = false;
@@ -1984,7 +1984,7 @@ void mainWindow::on_editindex(ustring indexName, ustring location)
 			statusText += " ";
 			statusText += indexName;
 
-			// An error occured
+			// An error occurred
 			set_status(statusText);
 			return;
 		}
@@ -2811,7 +2811,7 @@ void mainWindow::on_addIndexButton_clicked()
 		statusText += " ";
 		statusText += name;
 
-		// An error occured
+		// An error occurred
 		set_status(statusText);
 	}
 	else
@@ -2870,7 +2870,7 @@ void mainWindow::on_removeIndexButton_clicked()
 			statusText += " ";
 			statusText += indexName;
 
-			// An error occured
+			// An error occurred
 			set_status(statusText);
 		}
 		else

--- a/Utils/CommandLine.cpp
+++ b/Utils/CommandLine.cpp
@@ -88,7 +88,7 @@ bool CommandLine::readFile(int fd, ssize_t maxSize,
 		}
 		else if (bytesRead == -1)
 		{
-			// An error occured
+			// An error occurred
 			if (errno != EINTR)
 			{
 				gotOutput = false;


### PR DESCRIPTION
Reported on the Debian package by lintian's spelling-error-in-binary
check.