### PR TITLE
Fix const correctness

### DIFF
--- a/IndexSearch/cjkv/CJKVTokenizer.cc
+++ b/IndexSearch/cjkv/CJKVTokenizer.cc
@@ -24,7 +24,7 @@
 
 #include "CJKVTokenizer.h"
 
-static char *unicode_get_utf8(const char *p, gunichar *result)
+static const char *unicode_get_utf8(const char *p, gunichar *result)
 {
 	*result = g_utf8_get_char(p);
 


### PR DESCRIPTION
This causes a build failure in current debian unstable (unclear to me why this seems to be a new failure, but I guess g_utf8_next_char() used to effectively cast away const).